### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>1.4.183</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request fixes one or more vulnerable libraries in this project.

For more information, please navigate to the corresponding [SourceClear report](https://darius.ops2.srcclr.io/teams/PaailrK/scans/1099755).

SourceClear generated this pull request to update the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `com.h2database:h2` | 1.3.176 | 1.4.183 | No |

The column above, **Breaking**, will state the likelihood that updating to the recommended library version will have breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository has granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-5d9e25957b184fb27a5c111a0907988963d4289bf74ae14250f96d728d44637b -->
